### PR TITLE
Remove ext_io_conf, otg_io_conf from usb_phy_config_t phy_config in usb_serial_init

### DIFF
--- a/src/esp32_usb_serial.cpp
+++ b/src/esp32_usb_serial.cpp
@@ -116,8 +116,6 @@ esp_err_t usb_serial_init() {
       .otg_speed =
           USB_PHY_SPEED_UNDEFINED,  // In Host mode, the speed is determined by
                                     // the connected device
-      .ext_io_conf = NULL,
-      .otg_io_conf = NULL,
   };
   if (ESP_OK != usb_new_phy(&phy_config, &phy_hdl)) {
     ESP_LOGE("USB_SERIAL","Failed to init USB PHY");


### PR DESCRIPTION
Hello! 

In attempting to use this lib with PlatformIO on a Lolin s2 mini, I came across this build error:

```
.pio/libdeps/lolin_s2_mini/esp32-usb-serial/src/esp32_usb_serial.cpp: In function 'esp_err_t usb_serial_init()':
.pio/libdeps/lolin_s2_mini/esp32-usb-serial/src/esp32_usb_serial.cpp:121:3: error: 'usb_phy_config_t' has no non-static data member named 'ext_io_conf'
```

In the test file https://github.com/luc-github/esp32-usb-serial/blob/83d29b9bdc04eef8108a65111c36396858232d8b/original_components/espressif__usb_host_cdc_acm/test/test_cdc_acm_host.c#L48 those fields aren't specified, so I figured it was probably safe to remove them.

My barebones PlatformIO example is available at https://github.com/smartin015/esp32-usb-serial-pio/ - currently builds, but I haven't attempted to run it on a device yet.